### PR TITLE
Add link to Nixpkgs in Download section

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -59,6 +59,7 @@ https://github.com/veusz/veusz/releases/download/veusz-{{ver}}
     <li><a href="http://portsmon.freebsd.org/portoverview.py?category=science&amp;portname=veusz">FreeBSD</a></li>
     <li><a href="http://packages.gentoo.org/package/sci-visualization/veusz">Gentoo</a></li>
     <li><a href="ftp://ftp.netbsd.org/pub/pkgsrc/current/pkgsrc/graphics/veusz/README.html">NetBSD</a></li>
+    <li><a href="https://search.nixos.org/packages?channel=unstable&query=veusz">Nixpkgs</a></li>
     <li><a href="http://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/math/veusz/">OpenBSD</a></li>
     <li><a href="http://software.opensuse.org/download.html?project=science&package=python-veusz">openSUSE</a></li>
     <li><a href="https://edge.launchpad.net/~jeremysanders/+archive/ppa">Ubuntu PPA</a></li>


### PR DESCRIPTION
Hi! I wanted to let you know that today, my [PR](https://github.com/NixOS/nixpkgs/pull/93897) got merged to package Veusz in Nixpkgs. People using NixOS and/or the Nix package manager will now be able to install Veusz very easily!

So, I have added a little list entry in the Downloads section to reflect the change.